### PR TITLE
Fix recipe destroy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ Style/StringLiterals:
   Exclude:
     - 'app/services/recipe_services/parser.rb'
     - 'app/services/recipe_services/ingredient.rb'
+
+AllCops:
+  UseCache: false

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -129,12 +129,7 @@ class RecipesController < ApplicationController
 
   def destroy
     @recipe = current_user.recipes.find(params[:id])
-
-    # Use a transaction to ensure all related records are deleted together
-    ActiveRecord::Base.transaction do
-      # The dependent: :destroy association will handle the recipe_ingredients deletion
-      @recipe.destroy
-    end
+    @recipe.destroy
 
     respond_to do |format|
       format.html { redirect_to recipes_path, notice: "Recipe was successfully deleted." }

--- a/app/javascript/components/recipe/RecipeEditor.jsx
+++ b/app/javascript/components/recipe/RecipeEditor.jsx
@@ -240,16 +240,13 @@ const RecipeEditor = ({
 
     return (
         <div className="relative mb-20 mt-16">
-            {/* Header section with delete button */}
-            <div className="mb-8 flex justify-end items-center">
-                <button
-                    onClick={handleDeleteClick}
-                    className="inline-flex items-center px-4 py-2 bg-gray-900/90 backdrop-blur-sm text-red-500 rounded-lg transition-colors duration-200 border border-gray-700 hover:border-red-500 hover:bg-red-500/10"
-                >
-                    <Trash2 size={18} className="mr-1" />
-                    Delete Recipe
-                </button>
-            </div>
+            {/* Delete confirmation popup */}
+            {showDeleteConfirm && (
+                <DeleteConfirmationDialog
+                    onConfirm={handleDeleteConfirm}
+                    onCancel={handleCancelDelete}
+                />
+            )}
 
             {/* File Tab at the top */}
             <div className="absolute -top-8 left-8 z-10">
@@ -260,6 +257,17 @@ const RecipeEditor = ({
                         </span>
                     </div>
                 </div>
+            </div>
+
+            {/* Header section with delete button */}
+            <div className="absolute -top-16 right-0">
+                <button
+                    onClick={handleDeleteClick}
+                    className="inline-flex items-center px-4 py-2 bg-gray-900/90 backdrop-blur-sm text-red-500 rounded-lg transition-colors duration-200 border border-gray-700 hover:border-red-500 hover:bg-red-500/10"
+                >
+                    <Trash2 size={18} className="mr-1" />
+                    Delete Recipe
+                </button>
             </div>
 
             {/* Main Recipe Card with consistent border */}
@@ -341,14 +349,6 @@ const RecipeEditor = ({
 
                 {/* Edit mode for recipe content */}
                 <div className="p-8 space-y-8">
-                    {/* Delete confirmation popup */}
-                    {showDeleteConfirm && (
-                        <DeleteConfirmationDialog
-                            onConfirm={handleDeleteConfirm}
-                            onCancel={handleCancelDelete}
-                        />
-                    )}
-
                     {/* Edit mode for ingredients */}
                     <div className="mb-8">
                         <div className="flex justify-between items-center mb-4">

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -14,7 +14,7 @@
 # servings :float, nullable
 class Recipe < ApplicationRecord
   belongs_to :user
-  belongs_to :recipe_category, dependent: :destroy
+  belongs_to :recipe_category
 
   has_many :recipe_ingredients, dependent: :destroy
   has_many :groceries, through: :recipe_ingredients


### PR DESCRIPTION
Move delete button to be above recipe card
remove dependent_destroy for recipe_categories on recipe.rb model
update controller to just delete the recipe which will handle the ingredients.