### PR TITLE
bypass codecov if the pr is created by dependabot

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        if: "sender != 'dependabot[bot]'"
 
   ignore:
     - "^.*console\\.log.*$"


### PR DESCRIPTION
dont enforce codecov on dependabot PRs